### PR TITLE
Features/kobo client chore

### DIFF
--- a/src/msftoolbox/kobo/data.py
+++ b/src/msftoolbox/kobo/data.py
@@ -1,6 +1,5 @@
-import json
 import requests
-from requests.auth import HTTPBasicAuth
+
 
 class KoboClient:
     """A class to interact with the Kobo API and extract data from specific assets/surveys."""
@@ -12,10 +11,10 @@ class KoboClient:
 
         Args:
             base_url (str): The base URL of the Kobo API.
-            api_token (str): The API token for token-based authentication. 
+            api_token (str): The API token for token-based authentication.
         """
         self.base_url = base_url
-        self.params = { 
+        self.params = {
             "format": "json"
         }
         self.headers = {
@@ -32,10 +31,9 @@ class KoboClient:
                 f"Error: {self.auth_status.get('Error')}"
             )
             raise RuntimeError(msg)
-        else:
-            print(f"Authentication succeeded")
+        print("Authentication succeeded")
 
-    def _check_auth(self): 
+    def _check_auth(self):
         # Check authentication by checking access to assets
         url = f"{self.base_url}/assets/"
         try:
@@ -69,7 +67,7 @@ class KoboClient:
         """
         url = f'{self.base_url}assets/'
         response = requests.get(url, params=self.params, headers=self.headers)
-        
+
         if response.status_code == 200:
             response_json = response.json()
             return response_json['results']
@@ -91,17 +89,17 @@ class KoboClient:
         """
         try:
             assets = self.list_assets()
-            
+
             # Loop through each item in the list of assets
             for item in assets:
                 # Check if the current item's name matches the asset_name
                 if item.get('name') == asset_name:
                     # Return the UID if a match is found
                     return item.get('uid')
-            
+
             # If no match is found, raise a ValueError
             raise ValueError(f"Asset name '{asset_name}' not found.")
-        
+
         except requests.exceptions.HTTPError as e:
             # Handle HTTP errors if needed
             raise e
@@ -121,7 +119,7 @@ class KoboClient:
         """
         url = f'{self.base_url}assets/{asset_uid}'
         response = requests.get(url, params=self.params, headers=self.headers)
-        
+
         if response.status_code == 200:
             response_json = response.json()
             return response_json
@@ -181,14 +179,14 @@ class KoboClient:
         """
         asset_dict = self.get_asset(asset_uid)
         survey_items = asset_dict['content']['survey']
-        
+
         extracted_data = []
 
         for item in survey_items:
-            type = item.get('type')
+            item_type = item.get('type')
 
             # Extract group from $xpath
-            xpath = item.get('$xpath', '') # None?
+            xpath = item.get('$xpath', '')
             path_parts = xpath.split('/')
 
             # Determine the  group based on the path parts
@@ -209,7 +207,7 @@ class KoboClient:
 
             # Create a dictionary with the extracted data
             data_entry = {
-                'type': type,
+                'type': item_type,
                 'group': group,
                 'name': name,
                 'label': label,
@@ -220,7 +218,6 @@ class KoboClient:
             extracted_data.append(data_entry)
 
         return extracted_data
-
 
     def get_asset_choice_items(self, asset_uid):
         """
@@ -255,7 +252,7 @@ class KoboClient:
 
             # Create a dictionary with the extracted data
             data_entry = {
-                'list_name':list_name,
+                'list_name': list_name,
                 'name': name,
                 'label': label
             }

--- a/src/tests/test_kobo.py
+++ b/src/tests/test_kobo.py
@@ -2,16 +2,16 @@ from unittest.mock import patch, Mock
 from msftoolbox.kobo.data import KoboClient
 
 # Mocked API token and base URL
-api_token = "mock_api_token"
-base_url = "https://kobo.example.com/"
-mock_asset_id_01 = "gh3NsxvpoBmltERFuKcVnD"
-mock_asset_id_02 = "tk7QwzjbiGvypNXUfLsCmH"
+API_TOKEN = "mock_api_token"
+BASE_URL = "https://kobo.example.com/"
+MOCK_ASSET_ID_01 = "gh3NsxvpoBmltERFuKcVnD"
+MOCK_ASSET_ID_02 = "tk7QwzjbiGvypNXUfLsCmH"
 
 # Mocked assets
 mock_results = {
     'results': [
-        {'name': 'Asset1', 'uid': f'{mock_asset_id_01}'},
-        {'name': 'Asset2', 'uid': f'{mock_asset_id_02}'}
+        {'name': 'Asset1', 'uid': f'{MOCK_ASSET_ID_01}'},
+        {'name': 'Asset2', 'uid': f'{MOCK_ASSET_ID_02}'}
     ]
 }
 
@@ -25,7 +25,7 @@ mock_asset_content = {
 }
 
 # Mocked paginated asset data
-mock_asset_data_page1 = {'results': [{'data': 'page1'}], 'next': f'{base_url}assets/{mock_asset_id_01}/data?format=json&limit=30000&start=30000'}
+mock_asset_data_page1 = {'results': [{'data': 'page1'}], 'next': f'{BASE_URL}assets/{MOCK_ASSET_ID_01}/data?format=json&limit=30000&start=30000'}
 mock_asset_data_page2 = {'results': [{'data': 'page2'}], 'next': None}
 
 # Mocked asset metadata
@@ -51,7 +51,7 @@ mock_asset_with_choices = {
 # Test for listing assets
 @patch.object(KoboClient, '_check_auth', return_value={"Authenticated": True, "Status_code": 200})
 def test_list_assets(mock_check_auth):
-    client = KoboClient(base_url=base_url, api_token=api_token)
+    client = KoboClient(base_url=BASE_URL, api_token=API_TOKEN)
     with patch('requests.get') as mock_get:
         mock_response = Mock()
         mock_response.status_code = 200
@@ -59,36 +59,36 @@ def test_list_assets(mock_check_auth):
         mock_get.return_value = mock_response
 
         assets = client.list_assets()
-        mock_get.assert_called_with(f'{base_url}assets/', params=client.params, headers=client.headers)
+        mock_get.assert_called_with(f'{BASE_URL}assets/', params=client.params, headers=client.headers)
         assert assets == mock_results['results'], "Asset list does not match expected results"
 
 # Test for getting asset UID
 @patch.object(KoboClient, '_check_auth', return_value={"Authenticated": True, "Status_code": 200})
 @patch.object(KoboClient, 'list_assets', return_value=mock_results['results'])
 def test_get_asset_uid(mock_list_assets, mock_check_auth):
-    client = KoboClient(base_url=base_url, api_token=api_token)
+    client = KoboClient(base_url=BASE_URL, api_token=API_TOKEN)
     asset_uid = client.get_asset_uid('Asset2')
-    assert asset_uid == f'{mock_asset_id_02}', "UID does not match expected value"
+    assert asset_uid == f'{MOCK_ASSET_ID_02}', "UID does not match expected value"
     mock_list_assets.assert_called_once()
 
 # Test for getting specific asset details
 @patch.object(KoboClient, '_check_auth', return_value={"Authenticated": True, "Status_code": 200})
 def test_get_asset(mock_check_auth):
-    client = KoboClient(base_url=base_url, api_token=api_token)
+    client = KoboClient(base_url=BASE_URL, api_token=API_TOKEN)
     with patch('requests.get') as mock_get:
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = mock_asset_content
         mock_get.return_value = mock_response
 
-        asset = client.get_asset(mock_asset_id_01)
-        mock_get.assert_called_with(f'{base_url}assets/{mock_asset_id_01}', params=client.params, headers=client.headers)
+        asset = client.get_asset(MOCK_ASSET_ID_01)
+        mock_get.assert_called_with(f'{BASE_URL}assets/{MOCK_ASSET_ID_01}', params=client.params, headers=client.headers)
         assert asset == mock_asset_content, "Asset content does not match expected value"
 
 # Test for getting paginated asset data
 @patch.object(KoboClient, '_check_auth', return_value={"Authenticated": True, "Status_code": 200})
 def test_get_asset_data(mock_check_auth):
-    client = KoboClient(base_url=base_url, api_token=api_token)
+    client = KoboClient(base_url=BASE_URL, api_token=API_TOKEN)
     with patch('requests.get') as mock_get:
         mock_response_page1 = Mock()
         mock_response_page1.status_code = 200
@@ -100,15 +100,15 @@ def test_get_asset_data(mock_check_auth):
 
         mock_get.side_effect = [mock_response_page1, mock_response_page2]
 
-        asset_data = client.get_asset_data(mock_asset_id_01)
+        asset_data = client.get_asset_data(MOCK_ASSET_ID_01)
         assert asset_data == [{'data': 'page1'}, {'data': 'page2'}], "Paginated asset data does not match expected results"
 
 # Test for getting asset metadata
 @patch.object(KoboClient, '_check_auth', return_value={"Authenticated": True, "Status_code": 200})
 @patch.object(KoboClient, 'get_asset', return_value=mock_asset_metadata)
 def test_get_asset_metadata(mock_get_asset, mock_check_auth):
-    client = KoboClient(base_url=base_url, api_token=api_token)
-    metadata = client.get_asset_metadata(mock_asset_id_01)
+    client = KoboClient(base_url=BASE_URL, api_token=API_TOKEN)
+    metadata = client.get_asset_metadata(MOCK_ASSET_ID_01)
     expected_metadata = [
         {'type': 'date', 'group': None, 'name': 'ASSESSMENT_DATE', 'label': ['Date of assessment', 'Date de l’évaluation'], 'hint': None, 'required': True, 'question_code': 'ASSESSMENT_DATE'},
         {'type': 'select_one', 'group': 'GRP1', 'name': 'Question_1', 'label': ['1. Full question written in English', '1. Full question written in another language'], 'hint': None, 'required': None, 'question_code': 'RPT1/GRP1/Question_1'}
@@ -120,10 +120,10 @@ def test_get_asset_metadata(mock_get_asset, mock_check_auth):
 @patch.object(KoboClient, '_check_auth', return_value={"Authenticated": True, "Status_code": 200})
 @patch.object(KoboClient, 'get_asset', return_value=mock_asset_with_choices)
 def test_get_asset_choice_items(mock_get_asset, mock_check_auth):
-    client = KoboClient(base_url=base_url, api_token=api_token)
-    
+    client = KoboClient(base_url=BASE_URL, api_token=API_TOKEN)
+
     # Call the get_asset_choice_items method
-    choice_items = client.get_asset_choice_items(mock_asset_id_01)
+    choice_items = client.get_asset_choice_items(MOCK_ASSET_ID_01)
 
     # Expected output
     expected_choice_items = [

--- a/src/tests/test_kobo.py
+++ b/src/tests/test_kobo.py
@@ -62,6 +62,7 @@ def test_list_assets(mock_check_auth):
         mock_get.assert_called_with(f'{BASE_URL}assets/', params=client.params, headers=client.headers)
         assert assets == mock_results['results'], "Asset list does not match expected results"
 
+
 # Test for getting asset UID
 @patch.object(KoboClient, '_check_auth', return_value={"Authenticated": True, "Status_code": 200})
 @patch.object(KoboClient, 'list_assets', return_value=mock_results['results'])
@@ -70,6 +71,7 @@ def test_get_asset_uid(mock_list_assets, mock_check_auth):
     asset_uid = client.get_asset_uid('Asset2')
     assert asset_uid == f'{MOCK_ASSET_ID_02}', "UID does not match expected value"
     mock_list_assets.assert_called_once()
+
 
 # Test for getting specific asset details
 @patch.object(KoboClient, '_check_auth', return_value={"Authenticated": True, "Status_code": 200})
@@ -84,6 +86,7 @@ def test_get_asset(mock_check_auth):
         asset = client.get_asset(MOCK_ASSET_ID_01)
         mock_get.assert_called_with(f'{BASE_URL}assets/{MOCK_ASSET_ID_01}', params=client.params, headers=client.headers)
         assert asset == mock_asset_content, "Asset content does not match expected value"
+
 
 # Test for getting paginated asset data
 @patch.object(KoboClient, '_check_auth', return_value={"Authenticated": True, "Status_code": 200})
@@ -102,6 +105,7 @@ def test_get_asset_data(mock_check_auth):
 
         asset_data = client.get_asset_data(MOCK_ASSET_ID_01)
         assert asset_data == [{'data': 'page1'}, {'data': 'page2'}], "Paginated asset data does not match expected results"
+
 
 # Test for getting asset metadata
 @patch.object(KoboClient, '_check_auth', return_value={"Authenticated": True, "Status_code": 200})

--- a/src/tests/test_kobo.py
+++ b/src/tests/test_kobo.py
@@ -4,13 +4,14 @@ from msftoolbox.kobo.data import KoboClient
 # Mocked API token and base URL
 api_token = "mock_api_token"
 base_url = "https://kobo.example.com/"
-mock_asset_id = 'gh3NsxvpoBmltERFuKcVnD'
+mock_asset_id_01 = "gh3NsxvpoBmltERFuKcVnD"
+mock_asset_id_02 = "tk7QwzjbiGvypNXUfLsCmH"
 
 # Mocked assets
 mock_results = {
     'results': [
-        {'name': 'Asset1', 'uid': 'gh3NsxvpoBmltERFuKcVnD'},
-        {'name': 'Asset2', 'uid': 'tk7QwzjbiGvypNXUfLsCmH'}
+        {'name': 'Asset1', 'uid': f'{mock_asset_id_01}'},
+        {'name': 'Asset2', 'uid': f'{mock_asset_id_02}'}
     ]
 }
 
@@ -24,7 +25,7 @@ mock_asset_content = {
 }
 
 # Mocked paginated asset data
-mock_asset_data_page1 = {'results': [{'data': 'page1'}], 'next': f'{base_url}assets/gh3NsxvpoBmltERFuKcVnD/data?format=json&limit=30000&start=30000'}
+mock_asset_data_page1 = {'results': [{'data': 'page1'}], 'next': f'{base_url}assets/{mock_asset_id_01}/data?format=json&limit=30000&start=30000'}
 mock_asset_data_page2 = {'results': [{'data': 'page2'}], 'next': None}
 
 # Mocked asset metadata
@@ -67,7 +68,7 @@ def test_list_assets(mock_check_auth):
 def test_get_asset_uid(mock_list_assets, mock_check_auth):
     client = KoboClient(base_url=base_url, api_token=api_token)
     asset_uid = client.get_asset_uid('Asset2')
-    assert asset_uid == 'tk7QwzjbiGvypNXUfLsCmH', "UID does not match expected value"
+    assert asset_uid == f'{mock_asset_id_02}', "UID does not match expected value"
     mock_list_assets.assert_called_once()
 
 # Test for getting specific asset details
@@ -80,8 +81,8 @@ def test_get_asset(mock_check_auth):
         mock_response.json.return_value = mock_asset_content
         mock_get.return_value = mock_response
 
-        asset = client.get_asset(mock_asset_id)
-        mock_get.assert_called_with(f'{base_url}assets/gh3NsxvpoBmltERFuKcVnD', params=client.params, headers=client.headers)
+        asset = client.get_asset(mock_asset_id_01)
+        mock_get.assert_called_with(f'{base_url}assets/{mock_asset_id_01}', params=client.params, headers=client.headers)
         assert asset == mock_asset_content, "Asset content does not match expected value"
 
 # Test for getting paginated asset data
@@ -99,7 +100,7 @@ def test_get_asset_data(mock_check_auth):
 
         mock_get.side_effect = [mock_response_page1, mock_response_page2]
 
-        asset_data = client.get_asset_data(mock_asset_id)
+        asset_data = client.get_asset_data(mock_asset_id_01)
         assert asset_data == [{'data': 'page1'}, {'data': 'page2'}], "Paginated asset data does not match expected results"
 
 # Test for getting asset metadata
@@ -107,7 +108,7 @@ def test_get_asset_data(mock_check_auth):
 @patch.object(KoboClient, 'get_asset', return_value=mock_asset_metadata)
 def test_get_asset_metadata(mock_get_asset, mock_check_auth):
     client = KoboClient(base_url=base_url, api_token=api_token)
-    metadata = client.get_asset_metadata(mock_asset_id)
+    metadata = client.get_asset_metadata(mock_asset_id_01)
     expected_metadata = [
         {'type': 'date', 'group': None, 'name': 'ASSESSMENT_DATE', 'label': ['Date of assessment', 'Date de l’évaluation'], 'hint': None, 'required': True, 'question_code': 'ASSESSMENT_DATE'},
         {'type': 'select_one', 'group': 'GRP1', 'name': 'Question_1', 'label': ['1. Full question written in English', '1. Full question written in another language'], 'hint': None, 'required': None, 'question_code': 'RPT1/GRP1/Question_1'}
@@ -122,7 +123,7 @@ def test_get_asset_choice_items(mock_get_asset, mock_check_auth):
     client = KoboClient(base_url=base_url, api_token=api_token)
     
     # Call the get_asset_choice_items method
-    choice_items = client.get_asset_choice_items(mock_asset_id)
+    choice_items = client.get_asset_choice_items(mock_asset_id_01)
 
     # Expected output
     expected_choice_items = [


### PR DESCRIPTION
- Changing reserved keyword 'type' to 'item_type'
- Removing unused imports
- Switching from hard-coded mock asset_ids to variables
- Applying PEP8 style guide